### PR TITLE
US010 - View information about capability leads

### DIFF
--- a/sql/2020-08-27-modify-capability.sql
+++ b/sql/2020-08-27-modify-capability.sql
@@ -1,0 +1,3 @@
+ALTER TABLE Capability MODIFY leadMessage VARCHAR(255);
+
+UPDATE Capability SET leadName = "Mr Happy", leadPhoto = "https://static.wikia.nocookie.net/mrmen/images/6/6c/MR_HAPPY-3A.PNG", leadMessage = "I am very happy to be leading the Engineering capability" WHERE capabilityName = "Engineering";

--- a/src/main/java/com/kainos/ea/backend/controller/CapabilityController.java
+++ b/src/main/java/com/kainos/ea/backend/controller/CapabilityController.java
@@ -12,8 +12,12 @@ import org.springframework.web.bind.annotation.ResponseBody;
 @RequestMapping("/capability")
 public class CapabilityController {
 
+    private CapabilityService capabilityService;
+
     @Autowired
-    CapabilityService capabilityService;
+    public CapabilityController(CapabilityService capabilityService) {
+        this.capabilityService = capabilityService;
+    }
 
     @GetMapping("/")
     public @ResponseBody Iterable<Capability> getCapabilities() {

--- a/src/main/java/com/kainos/ea/backend/controller/CapabilityController.java
+++ b/src/main/java/com/kainos/ea/backend/controller/CapabilityController.java
@@ -1,12 +1,14 @@
 package com.kainos.ea.backend.controller;
 
 import com.kainos.ea.backend.models.Capability;
-import com.kainos.ea.backend.service.CapabilityService;
+import com.kainos.ea.backend.services.CapabilityService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
+
+import java.util.List;
 
 @Controller
 @RequestMapping("/capability")
@@ -20,7 +22,8 @@ public class CapabilityController {
     }
 
     @GetMapping("/")
-    public @ResponseBody Iterable<Capability> getCapabilities() {
+    public @ResponseBody
+    List<Capability> getCapabilities() {
         return capabilityService.getCapabilities();
     }
 }

--- a/src/main/java/com/kainos/ea/backend/models/Capability.java
+++ b/src/main/java/com/kainos/ea/backend/models/Capability.java
@@ -8,6 +8,7 @@ import javax.persistence.Table;
 @Entity
 @Table(name = "Capability")
 public class Capability {
+
     @Id
     @Column(name = "capabilityName")
     private String capabilityName;
@@ -21,8 +22,30 @@ public class Capability {
     @Column(name = "leadMessage")
     private String leadMessage;
 
+    /*
+     *       CONSTRUCTORS
+     * */
+
     public Capability() {
     }
+
+    /*
+     *       OVERRIDDEN METHODS
+     * */
+
+    @Override
+    public String toString() {
+        return "Capability{" +
+                "capabilityName='" + capabilityName + '\'' +
+                ", leadName='" + leadName + '\'' +
+                ", leadPhoto='" + leadPhoto + '\'' +
+                ", leadMessage='" + leadMessage + '\'' +
+                '}';
+    }
+
+    /*
+     *       GETTERS AND SETTERS
+     * */
 
     public Capability(String capabilityName) {
         this.capabilityName = capabilityName;
@@ -58,15 +81,5 @@ public class Capability {
 
     public void setLeadMessage(String leadMessage) {
         this.leadMessage = leadMessage;
-    }
-
-    @Override
-    public String toString() {
-        return "Capability{" +
-                "capabilityName='" + capabilityName + '\'' +
-                ", leadName='" + leadName + '\'' +
-                ", leadPhoto='" + leadPhoto + '\'' +
-                ", leadMessage='" + leadMessage + '\'' +
-                '}';
     }
 }

--- a/src/main/java/com/kainos/ea/backend/repositories/CapabilityRepository.java
+++ b/src/main/java/com/kainos/ea/backend/repositories/CapabilityRepository.java
@@ -3,7 +3,9 @@ package com.kainos.ea.backend.repositories;
 import com.kainos.ea.backend.models.Capability;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
+
 public interface CapabilityRepository extends CrudRepository<Capability, String> {
 
-    Iterable<Capability> findAll();
+    List<Capability> findAll();
 }

--- a/src/main/java/com/kainos/ea/backend/services/CapabilityService.java
+++ b/src/main/java/com/kainos/ea/backend/services/CapabilityService.java
@@ -1,17 +1,23 @@
-package com.kainos.ea.backend.service;
+package com.kainos.ea.backend.services;
 
 import com.kainos.ea.backend.repositories.CapabilityRepository;
 import com.kainos.ea.backend.models.Capability;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class CapabilityService {
 
-    @Autowired
-    CapabilityRepository capabilityRepository;
+    private CapabilityRepository capabilityRepository;
 
-    public Iterable<Capability> getCapabilities() {
+    @Autowired
+    public CapabilityService(CapabilityRepository capabilityRepository) {
+        this.capabilityRepository = capabilityRepository;
+    }
+
+    public List<Capability> getCapabilities() {
         return capabilityRepository.findAll();
     }
 }

--- a/src/test/java/com/kainos/ea/backend/controllers/CapabilityControllerTest.java
+++ b/src/test/java/com/kainos/ea/backend/controllers/CapabilityControllerTest.java
@@ -2,6 +2,8 @@ package com.kainos.ea.backend.controllers;
 
 import com.kainos.ea.backend.BackendApplicationTests;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -12,17 +14,7 @@ import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-class CapabilityControllerTest extends BackendApplicationTests {
+@ExtendWith(MockitoExtension.class)
+class CapabilityControllerTest {
 
-    TestRestTemplate restTemplate = new TestRestTemplate();
-    HttpHeaders headers = new HttpHeaders();
-
-    @Test
-    public void when_CapabilityEndpointCalled_Expect_DataToContainBrianCox() {
-        HttpEntity<String> entity = new HttpEntity<>(null, headers);
-        ResponseEntity<String> response = restTemplate.exchange(createURLWithPort("/capability/"), HttpMethod.GET, entity, String.class);
-        String expected = "{\"capabilityName\":\"Data\",\"leadName\":\"Prof Brian Cox\",\"leadPhoto\":\"https://www.thetimes.co.uk/imageserver/image/%2Fmethode%2Ftimes%2Fprod%2Fweb%2Fbin%2Fa176808a-30d8-11eb-8bd6-64d3c9126a9b.jpg\",\"leadMessage\":\"I love space\"}";
-
-        assertTrue(Objects.requireNonNull(response.getBody()).contains(expected));
-    }
 }

--- a/src/test/java/com/kainos/ea/backend/controllers/CapabilityControllerTest.java
+++ b/src/test/java/com/kainos/ea/backend/controllers/CapabilityControllerTest.java
@@ -1,20 +1,33 @@
 package com.kainos.ea.backend.controllers;
 
-import com.kainos.ea.backend.BackendApplicationTests;
+import com.kainos.ea.backend.controller.CapabilityController;
+import com.kainos.ea.backend.models.Capability;
+import com.kainos.ea.backend.services.CapabilityService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 
-import java.util.Objects;
+import java.util.List;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 class CapabilityControllerTest {
 
+    @Mock
+    private CapabilityService capabilityService;
+
+    @Test
+    public void when_QueryingAllCapabilities_expect_ServiceCalledPassback() {
+        List<Capability> capabilities = List.of(new Capability());
+        Mockito.when(capabilityService.getCapabilities()).thenReturn(capabilities);
+        CapabilityController capabilityController = new CapabilityController(capabilityService);
+
+        List<Capability> results = capabilityController.getCapabilities();
+        Mockito.verify(capabilityService).getCapabilities();
+
+        assertEquals(capabilities, results);
+    }
 }

--- a/src/test/java/com/kainos/ea/backend/services/CapabilityServiceTest.java
+++ b/src/test/java/com/kainos/ea/backend/services/CapabilityServiceTest.java
@@ -1,0 +1,33 @@
+package com.kainos.ea.backend.services;
+
+import com.kainos.ea.backend.controller.CapabilityController;
+import com.kainos.ea.backend.models.Capability;
+import com.kainos.ea.backend.repositories.CapabilityRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@ExtendWith(MockitoExtension.class)
+public class CapabilityServiceTest {
+
+    @Mock
+    private CapabilityRepository capabilityRepository;
+
+    @Test
+    public void when_QueryingAllCapabilities_expect_RepositoryCalledPassback() {
+        List<Capability> capabilities = List.of(new Capability());
+        Mockito.when(capabilityRepository.findAll()).thenReturn(capabilities);
+        CapabilityService capabilityService = new CapabilityService(capabilityRepository);
+
+        List<Capability> results = capabilityService.getCapabilities();
+        Mockito.verify(capabilityRepository).findAll();
+
+        assertEquals(capabilities, results);
+    }
+}


### PR DESCRIPTION
As a Kainos Employee
I want to be able to view information about each capability lead
So that I know who the capability lead is

Acceptance criteria
- Can view name of capability lead
- Can view photo of capability lead
- Can view a message from capability lead

Tech notes
- API endpoint for capability returning basically the whole capability table
- UI page display the info