### PR TITLE
009 categorise training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ build/
 
 **/application.properties
 .DS_Store
-
+bin/

--- a/src/main/java/com/kainos/ea/backend/controllers/BandTrainingController.java
+++ b/src/main/java/com/kainos/ea/backend/controllers/BandTrainingController.java
@@ -24,7 +24,7 @@ public class BandTrainingController {
 
     @GetMapping("")
     public @ResponseBody
-    List<Training> getTrainingByBand(@RequestParam String bandName) {
-        return bandTrainingService.getTrainingByBand(bandName);
+    List<Training> getTrainingByBandSortedByTrainingType(@RequestParam String bandName) {
+        return bandTrainingService.getTrainingByBandSortedByTrainingType(bandName);
     }
 }

--- a/src/main/java/com/kainos/ea/backend/repositories/BandTrainingRepository.java
+++ b/src/main/java/com/kainos/ea/backend/repositories/BandTrainingRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface BandTrainingRepository extends CrudRepository<BandTraining, Short> {
 
-    List<BandTraining> findByBandName(String bandName);
+    List<BandTraining> findByBandNameOrderByTrainingType(String bandName);
 }

--- a/src/main/java/com/kainos/ea/backend/services/BandTrainingService.java
+++ b/src/main/java/com/kainos/ea/backend/services/BandTrainingService.java
@@ -22,8 +22,8 @@ public class BandTrainingService {
         this.bandTrainingRepository = bandTrainingRepository;
     }
 
-    public List<Training> getTrainingByBand(String bandName) {
-        List<BandTraining> bandTrainings = bandTrainingRepository.findByBandName(bandName);
+    public List<Training> getTrainingByBandSortedByTrainingType(String bandName) {
+        List<BandTraining> bandTrainings = bandTrainingRepository.findByBandNameOrderByTrainingType(bandName);
         List<Training> trainings = new ArrayList<>();
         for (BandTraining bandTraining : bandTrainings) {
             trainings.add(bandTraining.getTraining());

--- a/src/test/java/com/kainos/ea/backend/controllers/BandTrainingControllerTest.java
+++ b/src/test/java/com/kainos/ea/backend/controllers/BandTrainingControllerTest.java
@@ -21,11 +21,11 @@ class BandTrainingControllerTest {
     @Test
     public void when_QueryingTrainingByBand_expect_ServiceCalledPassback() {
         List<Training> training = List.of(new Training());
-        Mockito.when(bandTrainingService.getTrainingByBand("")).thenReturn(training);
+        Mockito.when(bandTrainingService.getTrainingByBandSortedByTrainingType("")).thenReturn(training);
         BandTrainingController bandTrainingController = new BandTrainingController(bandTrainingService);
 
-        List<Training> results = bandTrainingController.getTrainingByBand("");
-        Mockito.verify(bandTrainingService).getTrainingByBand("");
+        List<Training> results = bandTrainingController.getTrainingByBandSortedByTrainingType("");
+        Mockito.verify(bandTrainingService).getTrainingByBandSortedByTrainingType("");
 
         assertEquals(training, results);
     }

--- a/src/test/java/com/kainos/ea/backend/services/BandTrainingServiceTest.java
+++ b/src/test/java/com/kainos/ea/backend/services/BandTrainingServiceTest.java
@@ -26,11 +26,11 @@ public class BandTrainingServiceTest {
         Training training = new Training();
         List<Training> trainings = List.of(training);
         List<BandTraining> bandTrainings = List.of(new BandTraining((short) 0, band, training));
-        Mockito.when(bandTrainingRepository.findByBandName("")).thenReturn(bandTrainings);
+        Mockito.when(bandTrainingRepository.findByBandNameOrderByTrainingType("")).thenReturn(bandTrainings);
         BandTrainingService bandTrainingService = new BandTrainingService(bandTrainingRepository);
 
-        List<Training> results = bandTrainingService.getTrainingByBand("");
-        Mockito.verify(bandTrainingRepository).findByBandName("");
+        List<Training> results = bandTrainingService.getTrainingByBandSortedByTrainingType("");
+        Mockito.verify(bandTrainingRepository).findByBandNameOrderByTrainingType("");
 
         assertEquals(trainings, results);
     }


### PR DESCRIPTION
I've sorted trainings by their types so it acts like some kind of grouping

===USE CASE 009===
As a Kainos Employee,
I want to see the training information categorised by type within each band
So that I can see what category the training falls within

Acceptance Criteria
For each band, training options available are grouped into:
- Professional skills
- Technical skills
- Development programmes