### PR TITLE
Add OpenAPI library for generating API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,13 @@
 		<java.version>16</java.version>
 	</properties>
 	<dependencies>
+		<!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui -->
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-ui</artifactId>
+			<version>1.5.10</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-core</artifactId>

--- a/src/main/java/com/kainos/ea/backend/controllers/JobRoleController.java
+++ b/src/main/java/com/kainos/ea/backend/controllers/JobRoleController.java
@@ -33,8 +33,8 @@ public class JobRoleController {
         return jobRoleService.getAllJobRolesSortedByCapability();
     }
 
-    @PostMapping("/add")
-    public ResponseEntity<Object> addJobRole(@RequestBody JobRole jobRole){
+    @PostMapping(path = "/add")
+    public @ResponseBody ResponseEntity<Object> addJobRole(@RequestBody JobRole jobRole){
         try{
             jobRoleService.addJobRole(jobRole);
         } catch (IllegalArgumentException e){


### PR DESCRIPTION
Documentation can be accessed using this URL: [http://localhost:8080/swagger-ui.html](http://localhost:8080/swagger-ui.html)

=== USE CASE 027===
Create a document detailing the different api routes of the system.

Swagger

